### PR TITLE
Update deploy to kubernetes and cloudfoundry links

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ cd elasticsearch-chatbot
 
 ## 3. Deploy to IBM Cloud
 
-* [Kubernetes](#kubernetes)
-* [Cloud Foundry](#cloud-foundry)
+* [Kubernetes](#kubernetes-1)
+* [Cloud Foundry](#cloud-foundry-1)
 
 ### Kubernetes
 


### PR DESCRIPTION
In the "Deploy to IBM Cloud" section, clicking on the links redirected you to the architecture images above when you should be redirected to the corresponding deploy section of each one below. This change fixes this.